### PR TITLE
Added 403 template support

### DIFF
--- a/request_token/middleware.py
+++ b/request_token/middleware.py
@@ -10,6 +10,9 @@ from request_token.models import RequestToken
 from request_token.settings import JWT_QUERYSTRING_ARG
 from request_token.utils import decode
 
+from django.template import loader ## For rendering  a custom 403-page
+from request_token.settings import FOUR03_TEMPLATE
+
 logger = logging.getLogger(__name__)
 
 
@@ -69,8 +72,13 @@ class RequestTokenMiddleware(object):
             logger.warning(
                 "JWT token error (error code:'%s'): %s", key, ex
             )
-            response = HttpResponseForbidden(
-                u"Temporary link token error (code: %s)" % key
-            )
+            if FOUR03_TEMPLATE:
+                response = HttpResponseForbidden(
+                    loader.render_to_string(FOUR03_TEMPLATE)
+                )
+            else:
+                response = HttpResponseForbidden(
+                    u"Temporary link token error (code: %s)" % key
+                )
             response.error = ex
             return response

--- a/request_token/settings.py
+++ b/request_token/settings.py
@@ -7,3 +7,6 @@ JWT_QUERYSTRING_ARG = getattr(settings, 'JWT_QUERYSTRING_ARG', 'rt')
 
 # the fixed expiration check on Session tokens
 JWT_SESSION_TOKEN_EXPIRY = int(getattr(settings, 'JWT_SESSION_TOKEN_EXPIRY', 10))
+
+# Set the default 403 template value
+FOUR03_TEMPLATE = getattr(settings, 'FOUR03_TEMPLATE', None)


### PR DESCRIPTION
Added template based prettyfication of the 403 response for when a token is expired.

The `FOUR03_TEMPLATE` value can now be specified in the django project settings project, which then renders the 403 from an HTML page.