### PR TITLE
Enable usage with Django 1.10's MIDDLEWARE setting

### DIFF
--- a/request_token/middleware.py
+++ b/request_token/middleware.py
@@ -3,6 +3,13 @@
 import logging
 
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Fallback for Django < 1.10
+    MiddlewareMixin = object
+# For rendering  a custom 403-page
+from django.template import loader
 
 from jwt.exceptions import InvalidTokenError
 
@@ -10,13 +17,11 @@ from .models import RequestToken
 from .settings import JWT_QUERYSTRING_ARG, FOUR03_TEMPLATE
 from .utils import decode
 
-# For rendering  a custom 403-page
-from django.template import loader
 
 logger = logging.getLogger(__name__)
 
 
-class RequestTokenMiddleware(object):
+class RequestTokenMiddleware(MiddlewareMixin):
 
     """Extract and verify request tokens from incoming GET requests.
 

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
 """request_token default test settings."""
+from distutils.version import StrictVersion
+
+import django
+
+
+DJANGO_VERSION = StrictVersion(django.get_version())
+
 DEBUG = True
 
 DATABASES = {
@@ -21,7 +28,7 @@ INSTALLED_APPS = (
     'test_app'
 )
 
-MIDDLEWARE_CLASSES = [
+_MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -29,6 +36,11 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'request_token.middleware.RequestTokenMiddleware',
 ]
+
+if DJANGO_VERSION < StrictVersion('1.10.0'):
+    MIDDLEWARE_CLASSES = _MIDDLEWARE_CLASSES
+else:
+    MIDDLEWARE = _MIDDLEWARE_CLASSES
 
 TEMPLATES = [
     {


### PR DESCRIPTION
While the package was tested under 1.10, it was not tested using the new MIDDLEWARE
setting but instead the old MIDDLEWARE_CLASSES setting.

This PR does two things:

a) forces us to use the new MIDDLEWARE setting during testing under Django 1.10 and above.

b) utilises Django's MiddlewareMixin so that our Middleware can perform across versions.

Down the line, when MIDDLEWARE_CLASSES is official deprecated we will have to migrate
our middleware to the new format. Until then, this will have to be our solution if we
are to support old versions.