### PR TITLE
Add support for POST request handling

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+django = "*"
+pyjwt = "*"
+sqlparse = "*"
+"psycopg2" = "*"
+
+[dev-packages]
+tox = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,139 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "e28e101437755e7bca9b3255b55584921729a73cea1704a06e438b3c142ab42c"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "django": {
+            "hashes": [
+                "sha256:acdcc1f61fdb0a0c82a1d3bf1879a414e7732ea894a7632af7f6d66ec7ab5bb3",
+                "sha256:efbcad7ebb47daafbcead109b38a5bd519a3c3cd92c6ed0f691ff97fcdd16b45"
+            ],
+            "index": "pypi",
+            "version": "==2.1.2"
+        },
+        "psycopg2": {
+            "hashes": [
+                "sha256:0b9e48a1c1505699a64ac58815ca99104aacace8321e455072cee4f7fe7b2698",
+                "sha256:0f4c784e1b5a320efb434c66a50b8dd7e30a7dc047e8f45c0a8d2694bfe72781",
+                "sha256:0fdbaa32c9eb09ef09d425dc154628fca6fa69d2f7c1a33f889abb7e0efb3909",
+                "sha256:11fbf688d5c953c0a5ba625cc42dea9aeb2321942c7c5ed9341a68f865dc8cb1",
+                "sha256:19eaac4eb25ab078bd0f28304a0cb08702d120caadfe76bb1e6846ed1f68635e",
+                "sha256:3232ec1a3bf4dba97fbf9b03ce12e4b6c1d01ea3c85773903a67ced725728232",
+                "sha256:36f8f9c216fcca048006f6dd60e4d3e6f406afde26cfb99e063f137070139eaf",
+                "sha256:59c1a0e4f9abe970062ed35d0720935197800a7ef7a62b3a9e3a70588d9ca40b",
+                "sha256:6506c5ff88750948c28d41852c09c5d2a49f51f28c6d90cbf1b6808e18c64e88",
+                "sha256:6bc3e68ee16f571681b8c0b6d5c0a77bef3c589012352b3f0cf5520e674e9d01",
+                "sha256:6dbbd7aabbc861eec6b910522534894d9dbb507d5819bc982032c3ea2e974f51",
+                "sha256:6e737915de826650d1a5f7ff4ac6cf888a26f021a647390ca7bafdba0e85462b",
+                "sha256:6ed9b2cfe85abc720e8943c1808eeffd41daa73e18b7c1e1a228b0b91f768ccc",
+                "sha256:711ec617ba453fdfc66616db2520db3a6d9a891e3bf62ef9aba4c95bb4e61230",
+                "sha256:844dacdf7530c5c612718cf12bc001f59b2d9329d35b495f1ff25045161aa6af",
+                "sha256:86b52e146da13c896e50c5a3341a9448151f1092b1a4153e425d1e8b62fec508",
+                "sha256:985c06c2a0f227131733ae58d6a541a5bc8b665e7305494782bebdb74202b793",
+                "sha256:a86dfe45f4f9c55b1a2312ff20a59b30da8d39c0e8821d00018372a2a177098f",
+                "sha256:aa3cd07f7f7e3183b63d48300666f920828a9dbd7d7ec53d450df2c4953687a9",
+                "sha256:b1964ed645ef8317806d615d9ff006c0dadc09dfc54b99ae67f9ba7a1ec9d5d2",
+                "sha256:b2abbff9e4141484bb89b96eb8eae186d77bc6d5ffbec6b01783ee5c3c467351",
+                "sha256:cc33c3a90492e21713260095f02b12bee02b8d1f2c03a221d763ce04fa90e2e9",
+                "sha256:d7de3bf0986d777807611c36e809b77a13bf1888f5c8db0ebf24b47a52d10726",
+                "sha256:db5e3c52576cc5b93a959a03ccc3b02cb8f0af1fbbdc80645f7a215f0b864f3a",
+                "sha256:e168aa795ffbb11379c942cf95bf813c7db9aa55538eb61de8c6815e092416f5",
+                "sha256:e9ca911f8e2d3117e5241d5fa9aaa991cb22fb0792627eeada47425d706b5ec8",
+                "sha256:eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e",
+                "sha256:efa19deae6b9e504a74347fe5e25c2cb9343766c489c2ae921b05f37338b18d1",
+                "sha256:f4b0460a21f784abe17b496f66e74157a6c36116fa86da8bf6aa028b9e8ad5fe",
+                "sha256:f93d508ca64d924d478fb11e272e09524698f0c581d9032e68958cfbdd41faef"
+            ],
+            "index": "pypi",
+            "version": "==2.7.5"
+        },
+        "pyjwt": {
+            "hashes": [
+                "sha256:30b1380ff43b55441283cc2b2676b755cca45693ae3097325dea01f3d110628c",
+                "sha256:4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176"
+            ],
+            "index": "pypi",
+            "version": "==1.6.4"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+            ],
+            "version": "==2018.7"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec",
+                "sha256:d9cf190f51cbb26da0412247dfe4fb5f4098edb73db84e02f9fc21fdca31fed4"
+            ],
+            "index": "pypi",
+            "version": "==0.2.4"
+        }
+    },
+    "develop": {
+        "filelock": {
+            "hashes": [
+                "sha256:86fe6af56ae08ebc9c66d54ba3398c35b98916d0862d782b276a65816ff39392",
+                "sha256:97694f181bdf58f213cca0a7cb556dc7bf90e2f8eb9aa3151260adac56701afb"
+            ],
+            "version": "==3.0.9"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
+                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
+            ],
+            "version": "==0.8.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
+                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+            ],
+            "version": "==1.7.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        },
+        "tox": {
+            "hashes": [
+                "sha256:513e32fdf2f9e2d583c2f248f47ba9886428c949f068ac54a0469cac55df5862",
+                "sha256:75fa30e8329b41b664585f5fb837e23ce1d7e6fa1f7811f2be571c990f9d911b"
+            ],
+            "index": "pypi",
+            "version": "==3.5.3"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:686176c23a538ecc56d27ed9d5217abd34644823d6391cbeb232f42bf722baad",
+                "sha256:f899fafcd92e1150f40c8215328be38ff24b519cd95357fa6e78e006c7638208"
+            ],
+            "version": "==16.1.0"
+        }
+    }
+}

--- a/request_token/apps.py
+++ b/request_token/apps.py
@@ -25,7 +25,4 @@ def check_template(template):
     try:
         loader.get_template(template)
     except TemplateDoesNotExist:
-        raise ImproperlyConfigured(
-            "Custom request token template does not exist: '%s'"
-            % template
-        )
+        raise ImproperlyConfigured(f"Custom request token template does not exist: '{template}'")

--- a/request_token/context_processors.py
+++ b/request_token/context_processors.py
@@ -1,0 +1,15 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.functional import SimpleLazyObject
+
+
+def request_token(request):
+    """Adds a request_token to template context (if found on the request)."""
+    def _get_val():
+        try:
+            return request.token.jwt()
+        except AttributeError:
+            raise ImproperlyConfigured(
+                "Request has no 'token' attribute - is RequestTokenMiddleware installed?"
+            )
+
+    return {'request_token': SimpleLazyObject(_get_val)}

--- a/request_token/middleware.py
+++ b/request_token/middleware.py
@@ -2,7 +2,6 @@ import logging
 
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
 from django.template import loader
-
 from jwt.exceptions import InvalidTokenError
 
 from .models import RequestToken
@@ -52,13 +51,15 @@ class RequestTokenMiddleware:
             "authentication middleware is installed."
         )
 
-        token = request.GET.get(JWT_QUERYSTRING_ARG)
+        if request.method == 'GET':
+            token = request.GET.get(JWT_QUERYSTRING_ARG)
+        elif request.method == 'POST':
+            token = request.POST.get(JWT_QUERYSTRING_ARG)
+        else:
+            token = None
 
         if token is None:
             return self.get_response(request)
-
-        if request.method != 'GET':
-            return HttpResponseNotAllowed(['GET'])
 
         # in the event of an error we log it, but then let the request
         # continue - as the fact that the token cannot be decoded, or

--- a/request_token/models.py
+++ b/request_token/models.py
@@ -322,7 +322,7 @@ class RequestToken(models.Model):
         self.save()
         return log
 
-    def invalidate(self):
+    def expire(self):
         """Mark the token as expired immediately, effectively killing the token."""
         self.expiration_time = tz_now() - datetime.timedelta(microseconds=1)
         self.save()

--- a/request_token/models.py
+++ b/request_token/models.py
@@ -1,6 +1,3 @@
-"""request_token models."""
-from __future__ import unicode_literals
-
 import datetime
 import logging
 
@@ -9,9 +6,7 @@ from django.contrib.auth import login
 from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now as tz_now
-
 from jwt.exceptions import InvalidAudienceError
 
 from .exceptions import MaxUseError
@@ -30,7 +25,6 @@ class RequestTokenQuerySet(models.query.QuerySet):
         return RequestToken(scope=scope, **kwargs).save()
 
 
-@python_2_unicode_compatible
 class RequestToken(models.Model):
 
     """A link token, targeted for use by a known Django User.
@@ -328,6 +322,11 @@ class RequestToken(models.Model):
         self.save()
         return log
 
+    def invalidate(self):
+        """Mark the token as expired immediately, effectively killing the token."""
+        self.expiration_time = tz_now() - datetime.timedelta(microseconds=1)
+        self.save()
+
 
 def parse_xff(header_value):
     """
@@ -348,7 +347,6 @@ def parse_xff(header_value):
         return None
 
 
-@python_2_unicode_compatible
 class RequestTokenLog(models.Model):
 
     """Used to log the use of a RequestToken."""
@@ -417,7 +415,6 @@ class RequestTokenErrorLogQuerySet(models.query.QuerySet):
         )
 
 
-@python_2_unicode_compatible
 class RequestTokenErrorLog(models.Model):
 
     """Used to log errors that occur with the use of a RequestToken."""

--- a/request_token/templatetags/request_token_tags.py
+++ b/request_token/templatetags/request_token_tags.py
@@ -1,0 +1,18 @@
+from django import template
+from django.utils.html import format_html
+
+from ..settings import JWT_QUERYSTRING_ARG
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def request_token(context):
+    """Render a hidden form field containing request token."""
+    request_token = context.get('request_token')
+    if request_token:
+        return format_html(
+            '<input type="hidden" name="{}" value="{}">',
+            JWT_QUERYSTRING_ARG,
+            request_token
+        )
+    return ""

--- a/request_token/tests/test_context_processors.py
+++ b/request_token/tests/test_context_processors.py
@@ -1,0 +1,25 @@
+from unittest import mock
+
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpRequest
+from django.test import TestCase
+
+from ..context_processors import request_token
+from ..models import RequestToken
+
+
+@mock.patch.object(RequestToken, 'jwt', lambda t: 'foo')
+class ContextProcessorTests(TestCase):
+
+    def test_request_token_no_token(self):
+        request = HttpRequest()
+        context = request_token(request)
+        with self.assertRaises(ImproperlyConfigured):
+            # assert forces evaluation of SimpleLazyObject
+            assert context['request_token']
+
+    def test_request_token(self):
+        request = HttpRequest()
+        request.token = RequestToken()
+        context = request_token(request)
+        assert context['request_token'] == request.token.jwt()

--- a/request_token/tests/test_models.py
+++ b/request_token/tests/test_models.py
@@ -325,7 +325,7 @@ class RequestTokenTests(TestCase):
         request.user = get_user_model().objects.create_user(username="Hyde")
         self.assertRaises(InvalidAudienceError, token.authenticate, request)
 
-    def test_invalidate(self):
+    def test_expire(self):
         expiry = tz_now() + datetime.timedelta(days=1)
         token = RequestToken.objects.create_token(
             scope="foo",
@@ -333,7 +333,7 @@ class RequestTokenTests(TestCase):
             expiration_time=expiry
         )
         self.assertTrue(token.expiration_time == expiry)
-        token.invalidate()
+        token.expire()
         self.assertTrue(token.expiration_time < expiry)
 
     def test_parse_xff(self):

--- a/request_token/tests/test_models.py
+++ b/request_token/tests/test_models.py
@@ -325,6 +325,17 @@ class RequestTokenTests(TestCase):
         request.user = get_user_model().objects.create_user(username="Hyde")
         self.assertRaises(InvalidAudienceError, token.authenticate, request)
 
+    def test_invalidate(self):
+        expiry = tz_now() + datetime.timedelta(days=1)
+        token = RequestToken.objects.create_token(
+            scope="foo",
+            login_mode=RequestToken.LOGIN_MODE_NONE,
+            expiration_time=expiry
+        )
+        self.assertTrue(token.expiration_time == expiry)
+        token.invalidate()
+        self.assertTrue(token.expiration_time < expiry)
+
     def test_parse_xff(self):
 
         def assertMeta(meta, expected):

--- a/request_token/tests/test_templatetags.py
+++ b/request_token/tests/test_templatetags.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from ..settings import JWT_QUERYSTRING_ARG
+from ..templatetags.request_token_tags import request_token
+
+
+class TemplateTagTests(TestCase):
+
+    def test_request_token_missing(self):
+        context = {}
+        assert request_token(context) == ""
+
+    def test_request_token(self):
+        context = {'request_token': 'foo'}
+        assert request_token(context) == (
+            f'<input type="hidden" name="{JWT_QUERYSTRING_ARG}" value="foo">'
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-# no versions pinned - recommendation is to install your
-# preferred Django version first, then run this requirements file.
-Django
-PyJWT
-sqlparse
-psycopg2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-request-token",
-    version="0.8.2",
+    version="0.9-dev0",
     packages=find_packages(),
     install_requires=[
         'Django>=1.11',
@@ -30,6 +30,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,4 @@ commands =
     coverage erase
     coverage run --branch manage.py test request_token test_app
     coverage report -m
+    coverage html


### PR DESCRIPTION
Fixes #5 

---

This PR adds basic (/experimental) support for processing POST requests, using the Django CSRF pattern as its model. It adds a template tag and a context processor to enable a request token that comes in on a GET request (the standard 'magic link' method) to be passed into a form POST, and then stripped back out, so that it can be used. This implementation requires no change to the existing GET handling.

In addition, a new model method `RequestToken.expire()` is available to immediately invalidate a token - this gives explicit control to a function, rather than relying on the token to expire at some point. This enables the scenario where magic links are not expired on the initial GET (which is prone to failure due to caching of URLs, poor connections etc.), but on a subsequent POST.

Putting all of this together - the landing page for a link protected by a request_token querystring can add the request token to a form, which will then be handled by the middleware in the same way as the GET request (putting it on the request object).

```
<!-- template rendered on GET landing page -->
<form method="post">
    {% csrf_token %}
    {% request_token %}
    ...
</form>
```

This will render the `token.jwt()` output in a hidden field:

```html
<form method="post">
    <input type="hidden" name="csrfmiddlewaretoken" value="12345678">
    <input type="hidden" name="rt" value="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtYXgiOjEsInN1YiI6Im1hZ2ljX2xpbmtfbG9naW4iLCJtb2QiOiJzIiwianRpIjoxNzM5NSwiYXVkIjo5Mzc2NywiZXhwIjoxNMDI5MDcwLCJpYXQiOjE1NDEwMjg0NzB9.cpRoL0dKAB2XRLLNsV_F_vwIL39C2QqNAnwRgr6YoEE">
    ...
</form>
```

As with CSRF middleware, the `RequestTokenMiddleware` will automatically pick up the token, and add the token to the request object (as it would on a GET request). This means that you can decorate the request handling view with the `use_request_token` decorator, and use the `request.token` inside the function. If relevant, you can also now immediately invalidate the token should that be required.

```python
@use_request_token(scope='foo')
def process_form(request):
    """"View handler for form presented on initial GET request."""
    token = request.token
    do_something_with_token(token)
    ...
    # we don't want this token to be used again, so we immediately expire it
    token.expire()
    return HttpResponse('OK')
```