### PR TITLE
Look in request.body/GET/POST for request token

### DIFF
--- a/request_token/middleware.py
+++ b/request_token/middleware.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 from django.http import HttpResponseForbidden, HttpResponseNotAllowed
 from django.template import loader
@@ -51,10 +52,13 @@ class RequestTokenMiddleware:
             "authentication middleware is installed."
         )
 
-        if request.method == 'GET':
+        if request.method == 'GET' or request.method == 'POST':
             token = request.GET.get(JWT_QUERYSTRING_ARG)
-        elif request.method == 'POST':
-            token = request.POST.get(JWT_QUERYSTRING_ARG)
+            if not token and request.method == 'POST':
+                if request.META.get('CONTENT_TYPE') == 'application/json':
+                    token = json.loads(request.body).get(JWT_QUERYSTRING_ARG)
+                if not token:
+                    token = request.POST.get(JWT_QUERYSTRING_ARG)
         else:
             token = None
 

--- a/tests/tests/test_middleware.py
+++ b/tests/tests/test_middleware.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 from jwt import exceptions
@@ -44,6 +45,13 @@ class MiddlewareTests(TestCase):
         request.session = MockSession()
         return request
 
+    def post_request_with_JSON(self):
+        data = json.dumps({JWT_QUERYSTRING_ARG: self.token.jwt()})
+        request = self.factory.post('/', data, 'application/json')
+        request.user = self.user
+        request.session = MockSession()
+        return request
+
     def test_process_request_assertions(self):
         request = self.factory.get('/')
         self.assertRaises(AssertionError, self.middleware, request)
@@ -69,6 +77,11 @@ class MiddlewareTests(TestCase):
 
     def test_process_POST_request_with_valid_token(self):
         request = self.post_request()
+        self.middleware(request)
+        self.assertEqual(request.token, self.token)
+
+    def test_process_POST_request_with_valid_token_with_json(self):
+        request = self.post_request_with_JSON()
         self.middleware(request)
         self.assertEqual(request.token, self.token)
 


### PR DESCRIPTION
**What has changed**
For GET requests, nothing has changed.
For POST requests, instead of looking in `request.POST` the middleware now looks in `request.GET`, `request.body` then `request.POST` (in that order).

**Why has this changed**
This allows AJAX requests to be made to views that require a request_token, since `request.POST` is empty if content-type is 'application/json'. We are also checking `request.GET` since it means we can put the request-token in the url for the POST action, and don't have to pass it down, and add it to the body. 