### PR TITLE
Add template tag for rendering query strings

### DIFF
--- a/request_token/templatetags/request_token_tags.py
+++ b/request_token/templatetags/request_token_tags.py
@@ -16,3 +16,12 @@ def request_token(context):
             request_token
         )
     return ""
+
+
+@register.simple_tag(takes_context=True)
+def request_token_querystring(context):
+	"""Render a query-string with the request token if it exists."""
+	request = context.get('request')
+	if getattr(request, 'token', None):
+		return f'?{JWT_QUERYSTRING_ARG}={request.token.jwt()}'
+	return ""

--- a/tests/tests/test_templatetags.py
+++ b/tests/tests/test_templatetags.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from django.test import TestCase
 
 from request_token.settings import JWT_QUERYSTRING_ARG
@@ -14,4 +15,18 @@ class TemplateTagTests(TestCase):
         context = {'request_token': 'foo'}
         assert request_token_tags.request_token(context) == (
             f'<input type="hidden" name="{JWT_QUERYSTRING_ARG}" value="foo">'
+        )
+
+    def test_request_token_querystring_missing(self):
+        mock_request = mock.Mock()
+        mock_request.token = None
+        context = {'request': mock_request}
+        assert request_token_tags.request_token_querystring(context) == ""
+
+    def test_request_token_querystring(self):
+        mock_request = mock.Mock()
+        mock_request.token.jwt.return_value = "foo"
+        context = {'request': mock_request}
+        assert request_token_tags.request_token_querystring(context) == (
+            f"?{JWT_QUERYSTRING_ARG}=foo"
         )


### PR DESCRIPTION
**What has changed**
A template tag has been added which renders the query-string to append to the end of a url.

**Why has this changed**
This is simply for convenience in templates to avoid things such as:
{% if request.token %}{{JWT_QUERYSTRING_ARG}}?={{request.token.jwt}}{% endif %}