### PR TITLE
Pin PyJWT to 1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ packages = [{ include = "request_token" }]
 [tool.poetry.dependencies]
 python = "^3.7"
 django = "^2.2 || ^3.0"
-pyjwt = "*"
+# pyjwt 2.0 changes encode/decode functions and a lot of other
+# dependencies require < 2, so this needs to be pinned for now.
+pyjwt = "^1.7"
 sqlparse = "*"
 
 [tool.poetry.dev-dependencies]

--- a/request_token/models.py
+++ b/request_token/models.py
@@ -234,7 +234,7 @@ class RequestToken(models.Model):
 
     def jwt(self) -> str:
         """Encode the token claims into a JWT."""
-        return encode(self.claims)
+        return encode(self.claims).decode()
 
     def validate_max_uses(self) -> None:
         """

--- a/request_token/utils.py
+++ b/request_token/utils.py
@@ -35,14 +35,14 @@ def check_mandatory_claims(
             raise exceptions.MissingRequiredClaimError(claim)
 
 
-def encode(payload: dict, check_claims: Sequence[str] = MANDATORY_CLAIMS) -> str:
+def encode(payload: dict, check_claims: Sequence[str] = MANDATORY_CLAIMS) -> bytes:
     """Encode JSON payload (using SECRET_KEY)."""
     check_mandatory_claims(payload, claims=check_claims)
     return jwt_encode(payload, settings.SECRET_KEY)
 
 
 def decode(
-    token: str,
+    token: bytes,
     options: Optional[Dict[str, bool]] = None,
     check_claims: Optional[Sequence[str]] = None,
     algorithms: Optional[List[str]] = None,


### PR DESCRIPTION
The 1.7 to 2.0 upgrade is not backwards compatible, and this causes
issues with other packages that are pinned.