### PR TITLE
Add support for User models using uuid as pk

### DIFF
--- a/request_token/models.py
+++ b/request_token/models.py
@@ -193,7 +193,7 @@ class RequestToken(models.Model):
         if self.id is not None:
             claims["jti"] = self.id
         if self.user is not None:
-            claims["aud"] = self.user.id
+            claims["aud"] = str(self.user.pk)
         if self.expiration_time is not None:
             claims["exp"] = to_seconds(self.expiration_time)
         if self.issued_at is not None:
@@ -235,6 +235,17 @@ class RequestToken(models.Model):
     def jwt(self) -> str:
         """Encode the token claims into a JWT."""
         return encode(self.claims)
+
+    def increment_used_count(self) -> None:
+        """
+
+        add 1 (One) to the used_to_date field
+
+        """
+
+        self.used_to_date = self.used_to_date + 1
+        self.save()
+
 
     def validate_max_uses(self) -> None:
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -92,7 +92,7 @@ class RequestTokenTests(TestCase):
 
         # now let's set some properties
         token.user = self.user
-        self.assertEqual(token.aud, self.user.id)
+        self.assertEqual(token.aud, str(self.user.pk))
         self.assertEqual(len(token.claims), 4)
 
         token.login_mode = RequestToken.LOGIN_MODE_REQUEST
@@ -209,6 +209,7 @@ class RequestTokenTests(TestCase):
         token.used_to_date = token.max_uses
         self.assertRaises(MaxUseError, token.validate_max_uses)
 
+
     def test__auth_is_anonymous(self):
         factory = RequestFactory()
         middleware = SessionMiddleware(get_response)
@@ -309,6 +310,12 @@ class RequestTokenTests(TestCase):
 
         request.user = get_user_model().objects.create_user(username="Hyde")
         self.assertRaises(InvalidAudienceError, token.authenticate, request)
+
+
+    def test_increment_used_count(self):
+        token = RequestToken(max_uses=1, used_to_date=0)
+        token.increment_used_count()
+        self.assertEqual(str(token.used_to_date), '1')
 
     def test_expire(self):
         expiry = tz_now() + datetime.timedelta(days=1)


### PR DESCRIPTION
A simple change to use the string value of the user object ( str(user.pk) ) to populate the 'aud' value in token claims.
Also added a increment_used_count helper function to the RequestToken model.