### PR TITLE
Add log param to use_request_token decorator

### DIFF
--- a/request_token/models.py
+++ b/request_token/models.py
@@ -230,7 +230,7 @@ class RequestToken(models.Model):
                     + datetime.timedelta(minutes=JWT_SESSION_TOKEN_EXPIRY)
                 )
         self.clean()
-        super(RequestToken, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
         return self
 
     def jwt(self) -> str:
@@ -390,5 +390,5 @@ class RequestTokenLog(models.Model):
     def save(self, *args: Any, **kwargs: Any) -> RequestToken:
         if "update_fields" not in kwargs:
             self.timestamp = self.timestamp or tz_now()
-        super(RequestTokenLog, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
         return self

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -14,7 +14,7 @@ from request_token.models import RequestToken
 from request_token.settings import JWT_QUERYSTRING_ARG
 
 
-class MockSession(object):
+class MockSession:
     """Fake Session model used to support `session_key` property."""
 
     @property

--- a/tests/views.py
+++ b/tests/views.py
@@ -5,14 +5,14 @@ from request_token.decorators import use_request_token
 
 
 def undecorated(request):
-    response = HttpResponse(u"Hello, %s" % request.user)
+    response = HttpResponse("Hello, %s" % request.user)
     response.request_user = request.user
     return response
 
 
 @use_request_token(scope="foo")
 def decorated(request):
-    response = HttpResponse(u"Hello, %s" % request.user)
+    response = HttpResponse("Hello, %s" % request.user)
     response.request_user = request.user
     return response
 


### PR DESCRIPTION
Possible solution for #55 

The current `DISABLE_LOGS` setting is a global switch for all requests. I have added a param called `log` to the `use_request_token` decorator to provide per-view control - so that you can mix-and-match logging. In this specific case I have included a test to show how you would decorate a view function that deletes the request.user - which you can't log as the model field cascade will delete the associated token.

