### PR TITLE
Catch UnicodeDecodeError in extract_ajax_token

### DIFF
--- a/request_token/exceptions.py
+++ b/request_token/exceptions.py
@@ -4,6 +4,7 @@ Local exceptions related to tokens.
 These exceptions all inherit from the PyJWT base InvalidTokenError.
 
 """
+
 from __future__ import annotations
 
 from jwt.exceptions import InvalidTokenError

--- a/request_token/management/commands/truncate_request_token_log.py
+++ b/request_token/management/commands/truncate_request_token_log.py
@@ -7,6 +7,7 @@ max number of rows to retain, or date - so that logs are only kept for a
 period of time.
 
 """
+
 from argparse import ArgumentParser
 from datetime import datetime, timedelta
 from typing import Any

--- a/request_token/middleware.py
+++ b/request_token/middleware.py
@@ -34,6 +34,9 @@ class RequestTokenMiddleware:
             payload = json.loads(request.body)
         except json.decoder.JSONDecodeError:
             return None
+        except UnicodeDecodeError:
+            return None
+
         try:
             return payload.get(JWT_QUERYSTRING_ARG)
         except AttributeError:
@@ -104,3 +107,4 @@ class RequestTokenMiddleware:
         if isinstance(exception, InvalidTokenError):
             logger.exception("JWT request token error, raising 403")
             raise PermissionDenied("Invalid request token.")
+

--- a/request_token/middleware.py
+++ b/request_token/middleware.py
@@ -107,4 +107,3 @@ class RequestTokenMiddleware:
         if isinstance(exception, InvalidTokenError):
             logger.exception("JWT request token error, raising 403")
             raise PermissionDenied("Invalid request token.")
-

--- a/request_token/utils.py
+++ b/request_token/utils.py
@@ -1,4 +1,5 @@
 """Basic encode/decode utils, taken from PyJWT."""
+
 from __future__ import annotations
 
 import calendar

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -147,3 +147,16 @@ class MiddlewareTests(TestCase):
         request = self.post_request_with_JSON(self.default_payload)
         middleware = RequestTokenMiddleware(lambda r: HttpResponse())
         self.assertEqual(middleware.extract_ajax_token(request), self.token.jwt())
+
+    def test_extract_ajax_token_catches_unicode_error(self):
+        request = self.factory.post(
+            "/",
+            data=b"\xa0",  # Invalid UTF-8 data
+            content_type="application/json"
+        )
+        request.user = self.user
+        request.session = MockSession()
+
+        middleware = RequestTokenMiddleware(get_response=lambda r: HttpResponse())
+        result = middleware.extract_ajax_token(request)
+        self.assertIsNone(result)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -150,9 +150,7 @@ class MiddlewareTests(TestCase):
 
     def test_extract_ajax_token_catches_unicode_error(self):
         request = self.factory.post(
-            "/",
-            data=b"\xa0",  # Invalid UTF-8 data
-            content_type="application/json"
+            "/", data=b"\xa0", content_type="application/json"  # Invalid UTF-8 data
         )
         request.user = self.user
         request.session = MockSession()

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     ruff
 
 commands =
-    ruff request_token
+    ruff check request_token
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
Ensure that any unicode decoding errors are caught while we load the json request body. If that's the case, return `None` from `extract_ajax_token`.

This fixes the scenario where invalid `utf-8` characters pass through `json.loads()` and cause the program to crash.

This PR is in response to #62.