### PR TITLE
Fix InvalidJTIError by Casting jti to String

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ following JWT claims (available as the property `RequestToken.claims`:
 * `max`: maximum times the token can be used
 * `sub`: the scope
 * `mod`: the login mode
-* `jti`: the token id
+* `jti`: the token id (str, as [pyjwt >= 2.10](https://github.com/jpadilla/pyjwt/releases/tag/2.10.0) now validates as a string)
 * `aud`: (optional) the user the token represents
 * `exp`: (optional) the expiration time of the token
 * `iat`: (optional) the time the token was issued

--- a/request_token/models.py
+++ b/request_token/models.py
@@ -169,7 +169,7 @@ class RequestToken(models.Model):
         return self.claims.get("iat")
 
     @property
-    def jti(self) -> int | None:
+    def jti(self) -> str | None:
         """Return the 'jti' claim, mapped to id."""
         return self.claims.get("jti")
 
@@ -192,7 +192,7 @@ class RequestToken(models.Model):
             "mod": self.login_mode[:1].lower(),
         }
         if self.id is not None:
-            claims["jti"] = self.id
+            claims["jti"] = str(self.id)
         if self.user is not None:
             claims["aud"] = str(self.user.pk)
         if self.expiration_time is not None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,7 +116,7 @@ class RequestTokenTests(TestCase):
         with mock.patch("request_token.models.tz_now", lambda: now):
             token.save()
             self.assertEqual(token.iat, now_sec)
-            self.assertEqual(token.jti, token.id)
+            self.assertEqual(token.jti, str(token.id))
             self.assertEqual(len(token.claims), 8)
 
     def test_json(self):


### PR DESCRIPTION
Good evening everyone,

This PR addresses an issue introduced from pyjwt version 2.10, where the library now enforces that the `jti` (JWT ID) claim must be a string (see the [2.10.0 release notes](https://github.com/jpadilla/pyjwt/releases/tag/2.10.0)). Previously, the implementation in django-request-token was adding the `jti` as an integer, which led to me stuck on the following error during token validation:

```
jwt.exceptions.InvalidJTIError: JWT ID must be a string
```

**What’s Changed:**

- The code now casts the `jti` claim to a string before including it in the token payload.
- This change aligns  with the updated pyjwt validation rules, preventing the error and ensuring proper token validation.

Thanks for reviewing this PR! I look forward to your feedback.
