### PR TITLE
Fix JWT 'jti' claim to be string for PyJWT 2.10+ compatibility

### DIFF
--- a/request_token/models.py
+++ b/request_token/models.py
@@ -169,7 +169,7 @@ class RequestToken(models.Model):
         return self.claims.get("iat")
 
     @property
-    def jti(self) -> int | None:
+    def jti(self) -> str | None:
         """Return the 'jti' claim, mapped to id."""
         return self.claims.get("jti")
 
@@ -192,7 +192,7 @@ class RequestToken(models.Model):
             "mod": self.login_mode[:1].lower(),
         }
         if self.id is not None:
-            claims["jti"] = self.id
+            claims["jti"] = str(self.id)
         if self.user is not None:
             claims["aud"] = str(self.user.pk)
         if self.expiration_time is not None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,7 +116,7 @@ class RequestTokenTests(TestCase):
         with mock.patch("request_token.models.tz_now", lambda: now):
             token.save()
             self.assertEqual(token.iat, now_sec)
-            self.assertEqual(token.jti, token.id)
+            self.assertEqual(token.jti, str(token.id))
             self.assertEqual(len(token.claims), 8)
 
     def test_json(self):


### PR DESCRIPTION
PyJWT 2.10.0 introduced stricter validation requiring the 'jti' (JWT ID) claim to be a string, as per the JWT specification. This change ensures our code is compliant by converting the model's integer ID to a string when encoding the JWT.

- Convert jti claim to string in RequestToken.claims property
- Update jti property return type annotation to str
- Update test to expect string jti value

This fixes issue #65 and ensures compatibility with PyJWT 2.10.0+