### PR TITLE
Misc: Issue breaking change to move decorator to secure-by-default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,11 @@ All notable changes to this project will be documented in this file.
     time, so any missing argument will be caught in local dev or CI
     before reaching production.
 
+### Dependencies
+
+-   Minimum PyJWT version bumped from 2.0 to 2.11 (for `jwt.types.Options`
+    TypedDict used in type annotations).
+
 ### Migration
 
 Replace all bare usages:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.0] - 2026-02-16
+
+### Breaking Changes
+
+-   The `required` parameter on `@use_request_token` is now mandatory.
+    Previously it defaulted to `False`, which meant decorating a view
+    with `@use_request_token(scope="foo")` provided no access control
+    at all — requests without a token were silently passed through.
+
+    This was a security footgun: developers reasonably expected that
+    adding the decorator would enforce token presence, but it didn't.
+
+    We chose to make `required` mandatory rather than simply flipping the
+    default to `True` because a silent default change could break existing
+    views that intentionally allow token-less requests. Making it mandatory
+    forces every call site to be reviewed and explicitly opt in or out.
+
+    You must now explicitly pass `required=True` or `required=False`
+    on every call site. Omitting it raises `TypeError` at import/startup
+    time, so any missing argument will be caught in local dev or CI
+    before reaching production.
+
+### Migration
+
+Replace all bare usages:
+
+```python
+# Before
+@use_request_token(scope="foo")
+
+# After — choose one:
+@use_request_token(scope="foo", required=True)   # token must be present
+@use_request_token(scope="foo", required=False)  # token optional (old default)
+```
+
 ## [2.4.0] - 2025-06-18
 
 -   Add Django 5.1 and 5.2 support

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 django-request-token is a Django app that provides JWT-backed tokens for managing one-time/expiring URL access. It supports three login modes: NONE (public link), REQUEST (single-request auth), and SESSION (full session login). Built on PyJWT, it uses Django's SECRET_KEY for signing.
 
-**Requirements:** Python 3.12+, Django 5.2–6.0, PyJWT 2.0+
+**Requirements:** Python 3.12+, Django 5.2–6.0, PyJWT 2.11+
 
 ## Common Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+django-request-token is a Django app that provides JWT-backed tokens for managing one-time/expiring URL access. It supports three login modes: NONE (public link), REQUEST (single-request auth), and SESSION (full session login). Built on PyJWT, it uses Django's SECRET_KEY for signing.
+
+**Requirements:** Python 3.12+, Django 5.2–6.0, PyJWT 2.0+
+
+## Common Commands
+
+### Testing
+```bash
+# Run full test suite
+pytest --cov=request_token --verbose tests/
+
+# Run a single test file
+pytest tests/test_models.py -v
+
+# Run a single test
+pytest tests/test_models.py::RequestTokenTests::test_jwt -v
+
+# Run via tox (full matrix: Django 5.2/6.0 × Python 3.12/3.13)
+tox
+```
+
+### Linting & Formatting
+```bash
+ruff check request_token        # lint
+ruff format --check request_token  # format check
+ruff format request_token       # auto-format
+mypy request_token              # type check
+```
+
+### Django Checks
+```bash
+python manage.py check --fail-level WARNING
+python manage.py makemigrations --dry-run --check --verbosity 3
+```
+
+## Architecture
+
+### Core Flow
+1. **Middleware** (`middleware.py`) extracts JWT from querystring (`?rt=`), POST form, or AJAX JSON body, decodes it, fetches the `RequestToken` by `jti` claim, and attaches it to `request.token`
+2. **Decorator** `@use_request_token(scope)` on views validates scope, enforces max_uses, optionally authenticates the user, and logs usage
+3. **Models** — `RequestToken` stores token config (scope, login_mode, expiration, max_uses, user) and generates JWTs; `RequestTokenLog` is the audit trail
+
+### Key Modules
+- **`models.py`** — `RequestToken` (JWT generation, validation, authentication) and `RequestTokenLog` (audit)
+- **`middleware.py`** — `RequestTokenMiddleware` (JWT extraction & decoding, adds `request.token`)
+- **`decorators.py`** — `@use_request_token(scope, required, log)` for view-level token enforcement
+- **`utils.py`** — JWT encode/decode wrappers, format validation (`is_jwt`), claim checking
+- **`settings.py`** — App settings: `JWT_QUERYSTRING_ARG`, `JWT_SESSION_TOKEN_EXPIRY`, `DEFAULT_MAX_USES`, `DISABLE_LOGS`
+- **`exceptions.py`** — `MaxUseError`, `ScopeError`, `TokenNotFoundError` (all inherit `InvalidTokenError`)
+
+### Configuration
+App settings are accessed via `request_token.settings` and can be overridden in Django settings with the `REQUEST_TOKEN_` prefix (e.g., `REQUEST_TOKEN_DISABLE_LOGS`).
+
+## Code Style
+- **Ruff** for linting and formatting (line length 88, double quotes)
+- **mypy** with strict optional and untyped defs checking (disabled for admin, migrations, tests)
+- Tests use `django.test.TestCase` and `unittest.mock`; security/assert lint rules relaxed in tests

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ request token support afterwards.
 This project supports three core use cases, each of which is modelled using the `login_mode`
 attribute of a request token:
 
-1. ~~Single authenticated request~~ (DEPRECATED: use `django-visitor-pass`)
+1. Single authenticated request (but you may prefer [django-visitor-pass](https://github.com/yunojuno/django-visitor-pass))
 2. Public link with payload
-3. ~~Auto-login~~ (DEPRECATED: use `django-magic-link`)
+3. Auto-login (but you may prefer [django-magic-link](https://github.com/yunojuno/django-magic-link))
 
 **Single Request** (`RequestToken.LOGIN_MODE_REQUEST`)
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,33 @@ request token support afterwards.
 This project supports three core use cases, each of which is modelled using the `login_mode`
 attribute of a request token:
 
-1. Public link with payload
-2. ~~Single authenticated request~~ (DEPRECATED: use `django-visitor-pass`)
+1. ~~Single authenticated request~~ (DEPRECATED: use `django-visitor-pass`)
+2. Public link with payload
 3. ~~Auto-login~~ (DEPRECATED: use `django-magic-link`)
+
+**Single Request** (`RequestToken.LOGIN_MODE_REQUEST`)
+
+In Request mode, the request.user property is overridden by the user specified in the token, but
+only for a single request. This is useful for responding to a single action (e.g. RSVP,
+unsubscribe). If the user then navigates onto another page on the site, they will not be
+authenticated. If the user is already authenticated, but as a different user to the one in the
+token, then they will receive a 403 response.
+
+```python
+# this token will identify the request.user as a given user, but only for
+# a single request - not the entire session.
+token = RequestToken.objects.create_token(
+    scope="foo",
+    login_mode=RequestToken.LOGIN_MODE_REQUEST,
+    user=User.objects.get(username="hugo")
+)
+
+...
+
+@use_request_token(scope="foo", required=True)
+function view_func(request):
+    assert request.user == User.objects.get(username="hugo")
+```
 
 **Public Link** (`RequestToken.LOGIN_MODE_NONE`)
 
@@ -73,7 +97,7 @@ token = RequestToken.objects.create_token(
 
 ...
 
-@use_request_token(scope="foo")
+@use_request_token(scope="foo", required=False)
 function view_func(request):
     # extract the affiliate id from an token _if_ one is supplied
     affiliate_id = (
@@ -81,30 +105,6 @@ function view_func(request):
         if hasattr(request, 'token')
         else None
     )
-```
-
-**Single Request** (`RequestToken.LOGIN_MODE_REQUEST`)
-
-In Request mode, the request.user property is overridden by the user specified in the token, but
-only for a single request. This is useful for responding to a single action (e.g. RSVP,
-unsubscribe). If the user then navigates onto another page on the site, they will not be
-authenticated. If the user is already authenticated, but as a different user to the one in the
-token, then they will receive a 403 response.
-
-```python
-# this token will identify the request.user as a given user, but only for
-# a single request - not the entire session.
-token = RequestToken.objects.create_token(
-    scope="foo",
-    login_mode=RequestToken.LOGIN_MODE_REQUEST,
-    user=User.objects.get(username="hugo")
-)
-
-...
-
-@use_request_token(scope="foo")
-function view_func(request):
-    assert request.user == User.objects.get(username="hugo")
 ```
 
 **Auto-login** (`RequestToken.LOGIN_MODE_SESSION`)
@@ -143,12 +143,12 @@ function being called - i.e. the `token.scope` must match the function decorator
 token = RequestToken(scope="foo")
 
 # this will raise a 403 without even calling the function
-@use_request_token(scope="bar")
+@use_request_token(scope="bar", required=False)
 def incorrect_scope(request):
     pass
 
 # this will call the function as expected
-@use_request_token(scope="foo")
+@use_request_token(scope="foo", required=False)
 def correct_scope(request):
     pass
 ```
@@ -203,12 +203,13 @@ If the token cannot be verified it returns a 403.
 
 **request_token.decorators.use_request_token** - applies token permissions to views
 
-A function decorator that takes one mandatory kwargs (`scope`) and one optional kwargs (`required`).
+A function decorator that takes two mandatory kwargs (`scope` and `required`).
 The `scope` is used to match tokens to view functions - it's just a straight text match - the value
 can be anything you like, but if the token scope is 'foo', then the corresponding view function
 decorator scope must match. The `required` kwarg is used to indicate whether the view **must** have
-a token in order to be used, or not. This defaults to False - if a token **is** provided, then it
-will be validated, if not, the view function is called as is.
+a token in order to be used, or not. If `required=True` and no token is provided, a 403 is returned.
+If `required=False` and a token **is** provided it will be validated; if not, the view function is
+called as is.
 
 If the scopes do not match then a 403 is returned.
 
@@ -266,7 +267,7 @@ You now have a request token enabled URL. You can use this token to protect a vi
 the view decorator:
 
 ```python
-@use_request_token(scope="foo")
+@use_request_token(scope="foo", required=True)
 function foo(request):
     pass
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-request-token"
-version = "2.4.0"
+version = "3.0.0"
 description = "JWT-backed Django app for managing querystring tokens."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [{ include = "request_token" }]
 [tool.poetry.dependencies]
 python = "^3.12"
 django = ">=5.2,<7.0"
-pyjwt = "^2.0"
+pyjwt = "^2.11"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "*"

--- a/request_token/decorators.py
+++ b/request_token/decorators.py
@@ -23,8 +23,9 @@ def _get_request_arg(*args: Any) -> HttpRequest | None:
 
 def use_request_token(  # noqa: C901
     view_func: Callable | None = None,
+    *,
     scope: str | None = None,
-    required: bool = False,
+    required: bool,
     log: bool = True,
 ) -> Callable:
     """
@@ -39,9 +40,9 @@ def use_request_token(  # noqa: C901
     using the 'scope' kwarg - the scope must be provided, and must match the
     scope of the request token.
 
-    If the 'required' kwarg is True, then the view function expects a valid token
-    in all cases - and the decorator will raise TokenNotFoundError if one does
-    not exist.
+    The 'required' kwarg is mandatory. If True, the view function expects a
+    valid token in all cases - and the decorator will raise TokenNotFoundError
+    if one does not exist. If False, requests without a token are passed through.
 
     If the 'log' kwargs is False then the usage is not logged.
 

--- a/request_token/utils.py
+++ b/request_token/utils.py
@@ -13,18 +13,16 @@ from jwt import (
     exceptions,
     get_unverified_header,
 )
+from jwt.types import Options
 
 # verification options - signature and expiry date
-DEFAULT_DECODE_OPTIONS = {
+DEFAULT_DECODE_OPTIONS: Options = {
     "verify_signature": True,
     "verify_exp": True,
     "verify_nbf": True,
     "verify_iat": True,
     "verify_aud": False,
-    "verify_iss": False,  # we're only validating our own claims
-    "require_exp": False,
-    "require_iat": False,
-    "require_nbf": False,
+    "verify_iss": False,
 }
 
 MANDATORY_CLAIMS = ("jti", "sub", "mod")
@@ -47,7 +45,7 @@ def encode(payload: dict, check_claims: Sequence[str] = MANDATORY_CLAIMS) -> str
 
 def decode(
     token: str,
-    options: dict[str, bool] | None = None,
+    options: Options | None = None,
     check_claims: Sequence[str] | None = None,
     algorithms: list[str] | None = None,
 ) -> dict:

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -12,7 +12,7 @@ from request_token.templatetags.request_token_tags import request_token
 
 def get_url(url_name, token):
     """Helper to format urls with tokens."""
-    url = reverse("test_app:%s" % url_name)
+    url = reverse(url_name)
     if token:
         url += "?{}={}".format(JWT_QUERYSTRING_ARG, token.jwt())
     return url
@@ -30,6 +30,12 @@ class ViewTests(TransactionTestCase):
     def setUp(self):
         self.client = Client()
         self.user = get_user_model().objects.create_user("zoidberg")
+
+    def test_required_token__missing(self):
+        """Test that a required token view returns 403 when no token is provided."""
+        response = self.client.get(reverse("decorated"))
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(RequestTokenLog.objects.count(), 0)
 
     def test_request_token(self):
         """Test the request tokens only set the user for a single request."""

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -47,6 +47,23 @@ class DecoratorTests(TestCase):
         self.middleware(request)
         return request
 
+    def test_missing_scope(self):
+        with self.assertRaises(ValueError):
+            @use_request_token(scope="", required=True)
+            def view(request):
+                pass
+
+        with self.assertRaises(ValueError):
+            @use_request_token(scope=None, required=True)
+            def view(request):
+                pass
+
+    def test_missing_required(self):
+        with self.assertRaises(TypeError):
+            @use_request_token(scope="foo")
+            def view(request):
+                pass
+
     def test_no_token__required(self):
         request = self._request("/", None, AnonymousUser())
         self.assertRaises(TokenNotFoundError, sample_view_func, request)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -9,7 +9,7 @@ from request_token.models import RequestToken, RequestTokenLog
 from request_token.settings import JWT_QUERYSTRING_ARG
 
 
-@use_request_token(scope="foo")
+@use_request_token(scope="foo", required=True)
 def sample_view_func(request):
     """Return decorated request / response objects."""
     response = HttpResponse("Hello, world!", status=200)
@@ -17,7 +17,7 @@ def sample_view_func(request):
 
 
 class TestClassBasedView:
-    @use_request_token(scope="foobar")
+    @use_request_token(scope="foobar", required=True)
     def get(self, request):
         """Return decorated request / response objects."""
         response = HttpResponse(str(request.token.id), status=200)
@@ -47,19 +47,22 @@ class DecoratorTests(TestCase):
         self.middleware(request)
         return request
 
-    def test_no_token(self):
+    def test_no_token__required(self):
         request = self._request("/", None, AnonymousUser())
-        response = sample_view_func(request)
+        self.assertRaises(TokenNotFoundError, sample_view_func, request)
+        self.assertFalse(RequestTokenLog.objects.exists())
+
+    def test_no_token__not_required(self):
+        request = self._request("/", None, AnonymousUser())
+
+        @use_request_token(scope="foo", required=False)
+        def optional_token_view(request):
+            return HttpResponse("Hello, world!", status=200)
+
+        response = optional_token_view(request)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(hasattr(request, "token"))
         self.assertFalse(RequestTokenLog.objects.exists())
-
-        # now force a TokenNotFoundError, by requiring it in the decorator
-        @use_request_token(scope="foo", required=True)
-        def sample_view_func2(request):
-            pass
-
-        self.assertRaises(TokenNotFoundError, sample_view_func2, request)
 
     def test_scope(self):
         token = RequestToken.objects.create_token(scope="foobar")
@@ -96,7 +99,7 @@ class DecoratorTests(TestCase):
         request = self._request("/", token.jwt(), user)
         assert User.objects.count() == 1
 
-        @use_request_token(scope="foo", log=False)
+        @use_request_token(scope="foo", required=True, log=False)
         def delete_token_user_pass(request):
             request.user.delete()
             return HttpResponse("Hello, world!", status=204)
@@ -110,7 +113,7 @@ class DecoratorTests(TestCase):
         token = RequestToken.objects.create_token(user=user, scope="foo")
         request = self._request("/", token.jwt(), user)
 
-        @use_request_token(scope="foo", log=True)
+        @use_request_token(scope="foo", required=True, log=True)
         def delete_token_user(request):
             request.user.delete()
             return HttpResponse("Hello, world!", status=204)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.urls import path
 from django.views import debug
 
-from .views import decorated, roundtrip, undecorated
+from .views import decorated, optional, roundtrip, undecorated
 
 app_name = "tests"
 
@@ -12,6 +12,7 @@ urlpatterns = [
     path("", debug.default_urlconf),
     path("admin/", admin.site.urls),
     path("decorated/", decorated, name="decorated"),
+    path("optional/", optional, name="optional"),
     path("roundtrip/", roundtrip, name="roundtrip"),
     path("undecorated/", undecorated, name="undecorated"),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/tests/views.py
+++ b/tests/views.py
@@ -17,6 +17,13 @@ def decorated(request):
     return response
 
 
+@use_request_token(scope="foo", required=False)
+def optional(request):
+    response = HttpResponse("Hello, %s" % request.user)
+    response.request_user = request.user
+    return response
+
+
 @use_request_token(scope="bar", required=True)
 def roundtrip(request):
     if request.method == "GET":

--- a/tests/views.py
+++ b/tests/views.py
@@ -10,14 +10,14 @@ def undecorated(request):
     return response
 
 
-@use_request_token(scope="foo")
+@use_request_token(scope="foo", required=False)
 def decorated(request):
     response = HttpResponse("Hello, %s" % request.user)
     response.request_user = request.user
     return response
 
 
-@use_request_token(scope="bar")
+@use_request_token(scope="bar", required=False)
 def roundtrip(request):
     if request.method == "GET":
         return render(request, "test_form.html")

--- a/tests/views.py
+++ b/tests/views.py
@@ -10,14 +10,14 @@ def undecorated(request):
     return response
 
 
-@use_request_token(scope="foo", required=False)
+@use_request_token(scope="foo", required=True)
 def decorated(request):
     response = HttpResponse("Hello, %s" % request.user)
     response.request_user = request.user
     return response
 
 
-@use_request_token(scope="bar", required=False)
+@use_request_token(scope="bar", required=True)
 def roundtrip(request):
     if request.method == "GET":
         return render(request, "test_form.html")


### PR DESCRIPTION
<!-- COMMIT_MESSAGE_START -->
## Summary

The `required` parameter on the `@use_request_token` decorator is now a mandatory keyword argument. Previously it defaulted to `False`, which meant `@use_request_token(scope="foo")` by default silently passed through requests without a token — providing zero access control. Whilst this was how the library was original designed for internal use - it was the wrong decision for external users who have less knowledge of how it works and so we are doing the sensible thing and changing it.

Omitting `required` now raises `TypeError` at import/startup time, so missing arguments are caught in local dev or CI before reaching production.

We chose to make `required` mandatory rather than simply flipping the default to `True` because a silent default change could break existing views that intentionally allow token-less requests. Making it mandatory forces every call site to be reviewed and explicitly opt in or out.

This is a breaking change, so the version has been bumped to 3.0.0.

## Why is this change being made?

Developers reasonably expected that decorating a view with `@use_request_token` would enforce token presence, but the `required=False` default meant it didn't.

Beyond the decorator signature change, the README has been reordered to lead with the secure `required=True` pattern (Single Request) before the opt-out `required=False` pattern (Public Link), and all code examples now include an explicit `required` value. The DEPRECATED labels on alternative packages have been replaced with softer "but you may prefer" phrasing with links.

The test suite has been updated to reflect the secure-by-default posture: module-level view fixtures and all token-sending tests use `required=True`, with `required=False` only appearing where the optional-token path is explicitly under test. A pre-existing issue with the integration tests (broken URL namespace causing all integration tests to silently fail) has also been fixed.

<!-- COMMIT_MESSAGE_END -->

## Steps to test the change?

```bash
# Full test suite (78 tests)
pytest --cov=request_token --verbose tests/

# Lint & format
ruff check request_token
ruff format --check request_token

# Django checks
python manage.py check --fail-level WARNING
python manage.py makemigrations --dry-run --check --verbosity 3
```

To verify the breaking change works as intended, try decorating a view without `required`:

```python
@use_request_token(scope="foo")
def my_view(request):
    pass
```

This should raise `TypeError` at import time.